### PR TITLE
feat(download-retry): 支持在多个备用下载链接中重试下载

### DIFF
--- a/src/nonebot_plugin_parser_lite/download/__init__.py
+++ b/src/nonebot_plugin_parser_lite/download/__init__.py
@@ -1,5 +1,5 @@
 import asyncio
-from collections.abc import Callable, Generator
+from collections.abc import Callable, Collection, Generator, Sequence
 import contextlib
 from functools import partial
 import mimetypes
@@ -154,6 +154,8 @@ class StreamDownloader:
         self,
         *,
         url: str,
+        fallback_urls: Sequence[str] | None = None,
+        retry_http_statuses: Collection[int] = (),
         cache_key: str | None = None,
         default_suffix: str = ".bin",
         ext_headers: dict[str, str] | None = None,
@@ -162,6 +164,8 @@ class StreamDownloader:
     ) -> Path:
         """
         :param url: 下载文件的链接地址
+        :param fallback_urls: 主链接失败时轮换使用的同资源备用链接
+        :param retry_http_statuses: 可通过重试或切换线路恢复的 HTTP 状态码
         :param cache_key: 稳定缓存标识，为空时根据 URL 生成
         :param default_suffix: 响应和 URL 均无法确定后缀时使用的后缀名
         :param ext_headers: 额外的请求头，会与默认请求头合并
@@ -178,6 +182,13 @@ class StreamDownloader:
         cache_dir = await CacheManager.ensure_dir(cache_type)
         base_path = cache_dir / cache_name
         partial_path = cache_dir / f"{cache_name}.part"
+        download_urls = tuple(
+            dict.fromkeys(
+                candidate
+                for candidate in (url, *(fallback_urls or ()))
+                if candidate
+            )
+        )
 
         headers = _with_identity_encoding(self.headers | (ext_headers or {}))
         download_key = str(base_path)
@@ -189,12 +200,13 @@ class StreamDownloader:
             if cached_path := await CacheManager.get_cached_file(base_path):
                 return cached_path
             result = await self.__download_with_retry(
-                url=url,
+                download_urls=download_urls,
                 base_path=base_path,
                 partial_path=partial_path,
                 fallback_suffix=fallback_suffix,
                 headers=headers,
                 desc=f"{cache_name}{fallback_suffix}",
+                retry_http_statuses=frozenset(retry_http_statuses),
                 use_curl_cffi=use_curl_cffi,
             )
             await CacheManager.set_cached_file(base_path, result)
@@ -214,26 +226,29 @@ class StreamDownloader:
 
     async def __download_with_retry(
         self,
-        url: str,
+        download_urls: tuple[str, ...],
         base_path: Path,
         partial_path: Path,
         fallback_suffix: str,
         headers: dict[str, str],
         desc: str,
+        retry_http_statuses: frozenset[int],
         use_curl_cffi: bool = False,
     ) -> Path:
         last_error: Exception | None = None
 
         for retry in range(self.MAX_RETRIES + 1):
+            current_url = download_urls[retry % len(download_urls)]
             try:
                 content_type = await self.__download_once(
-                    url=url,
+                    url=current_url,
                     file_path=partial_path,
                     headers=headers,
                     desc=desc,
+                    retry_http_statuses=retry_http_statuses,
                     use_curl_cffi=use_curl_cffi,
                 )
-                suffix = _resolve_suffix(url, content_type, fallback_suffix)
+                suffix = _resolve_suffix(current_url, content_type, fallback_suffix)
                 file_path = base_path.with_suffix(suffix)
                 if await file_path.exists():
                     await safe_unlink(partial_path)
@@ -253,7 +268,7 @@ class StreamDownloader:
                 delay = min(2**retry, 8)
                 logger.warning(
                     f"下载失败，{delay} 秒后重试 ({retry + 1}/"
-                    f"{self.MAX_RETRIES}) | {url}: {last_error!r}"
+                    f"{self.MAX_RETRIES}) | {current_url}: {last_error!r}"
                 )
                 await asyncio.sleep(delay)
 
@@ -261,9 +276,19 @@ class StreamDownloader:
             f"在 {self.MAX_RETRIES} 次重试后下载失败"
         ) from last_error
 
-    def __validate_response(self, response: UniResponse, downloaded: int):
+    def __validate_response(
+        self,
+        response: UniResponse,
+        downloaded: int,
+        retry_http_statuses: Collection[int],
+    ):
         if downloaded > 0 and response.status_code == 416:
             raise RetryableDownloadError("断点位置无效，重新完整下载", keep_part=False)
+        if response.status_code in retry_http_statuses:
+            raise RetryableDownloadError(
+                f"HTTP {response.status_code}，切换下载线路后重试",
+                keep_part=False,
+            )
         response.raise_for_status()
         if downloaded > 0:
             self.__validate_header(response, downloaded)
@@ -298,6 +323,7 @@ class StreamDownloader:
         file_path: Path,
         headers: dict[str, str],
         desc: str,
+        retry_http_statuses: Collection[int],
         use_curl_cffi: bool,
     ) -> str | None:
         downloaded = (await file_path.stat()).st_size if await file_path.exists() else 0
@@ -307,7 +333,7 @@ class StreamDownloader:
             headers=self.__make_range_headers(headers, downloaded),
             use_curl_cffi=use_curl_cffi,
         ) as response:
-            self.__validate_response(response, downloaded)
+            self.__validate_response(response, downloaded, retry_http_statuses)
             content_encodings = _parse_content_encodings(
                 response.headers.get("content-encoding")
             )
@@ -404,6 +430,8 @@ class StreamDownloader:
         self,
         *,
         url: str,
+        fallback_urls: Sequence[str] | None = None,
+        retry_http_statuses: Collection[int] = (),
         cache_key: str | None = None,
         cache_variant: str | None = None,
         ext_headers: dict[str, str] | None = None,
@@ -414,6 +442,8 @@ class StreamDownloader:
         下载普通视频
 
         :param url: 视频下载地址
+        :param fallback_urls: 主链接失败时轮换使用的同资源备用链接
+        :param retry_http_statuses: 可通过重试或切换线路恢复的 HTTP 状态码
         :param cache_key: 视频的稳定缓存标识，为空时根据 URL 生成
         :param cache_variant: 同一资源下的视频用途标识
         :param ext_headers: 额外的请求头，会与默认请求头合并
@@ -427,6 +457,8 @@ class StreamDownloader:
         """
         return await self.streamd(
             url=url,
+            fallback_urls=fallback_urls,
+            retry_http_statuses=retry_http_statuses,
             cache_key=compose_cache_key("video", cache_key, cache_variant),
             default_suffix=".mp4",
             ext_headers=ext_headers,
@@ -728,6 +760,8 @@ class StreamDownloader:
         self,
         *,
         url: str,
+        fallback_urls: Sequence[str] | None = None,
+        retry_http_statuses: Collection[int] = (),
         cache_key: str | None = None,
         cache_variant: str | None = None,
         ext_headers: dict[str, str] | None = None,
@@ -739,6 +773,8 @@ class StreamDownloader:
         下载音频
 
         :param url: 音频下载地址
+        :param fallback_urls: 主链接失败时轮换使用的同资源备用链接
+        :param retry_http_statuses: 可通过重试或切换线路恢复的 HTTP 状态码
         :param cache_key: 音频的稳定缓存标识，为空时根据 URL 生成
         :param cache_variant: 同一资源下的音频用途标识
         :param ext_headers: 额外的请求头，会与默认请求头合并
@@ -751,6 +787,8 @@ class StreamDownloader:
         """
         audio_path = await self.streamd(
             url=url,
+            fallback_urls=fallback_urls,
+            retry_http_statuses=retry_http_statuses,
             cache_key=compose_cache_key("audio", cache_key, cache_variant),
             default_suffix=".mp3",
             ext_headers=ext_headers,
@@ -801,12 +839,18 @@ class StreamDownloader:
         cache_key: str | None = None,
         ext_headers: dict[str, str] | None = None,
         use_curl_cffi: bool = False,
+        video_fallback_urls: Sequence[str] | None = None,
+        audio_fallback_urls: Sequence[str] | None = None,
+        retry_http_statuses: Collection[int] = (),
     ) -> Path:
         """
         下载音频和视频文件并合并
 
         :param video_url: 视频流下载地址
         :param audio_url: 音频流下载地址
+        :param video_fallback_urls: 视频流备用下载地址
+        :param audio_fallback_urls: 音频流备用下载地址
+        :param retry_http_statuses: 可通过重试或切换线路恢复的 HTTP 状态码
         :param cache_key: 合并任务的稳定缓存标识，为空时根据两个 URL 生成
         :param ext_headers: 额外的请求头，会与默认请求头合并
         :param use_curl_cffi: 是否使用 curl_cffi 下载
@@ -824,6 +868,8 @@ class StreamDownloader:
         v_path, a_path = await asyncio.gather(
             self.download_video(
                 url=video_url,
+                fallback_urls=video_fallback_urls,
+                retry_http_statuses=retry_http_statuses,
                 cache_key=cache_key,
                 cache_variant="source" if cache_key is not None else None,
                 ext_headers=ext_headers,
@@ -831,6 +877,8 @@ class StreamDownloader:
             ),
             self.download_audio(
                 url=audio_url,
+                fallback_urls=audio_fallback_urls,
+                retry_http_statuses=retry_http_statuses,
                 cache_key=cache_key,
                 cache_variant="source" if cache_key is not None else None,
                 ext_headers=ext_headers,

--- a/src/nonebot_plugin_parser_lite/matchers/__init__.py
+++ b/src/nonebot_plugin_parser_lite/matchers/__init__.py
@@ -180,14 +180,16 @@ async def register_bili_matcher():
             bvid = bv.result
 
             page_idx = page.result - 1 if page.result > 0 else 0
-            _, audio_url = await bilip.extract_download_urls(
+            _, audio_stream = await bilip.get_download_streams(
                 bvid=bvid, page_index=page_idx
             )
-            if not audio_url:
+            if audio_stream is None:
                 await UniMessage("未找到可下载的音频").finish()
 
             audio_path = await DOWNLOADER.download_audio(
-                url=audio_url,
+                url=audio_stream.url,
+                fallback_urls=audio_stream.backup_url,
+                retry_http_statuses=bilip.BILI_RETRYABLE_HTTP_STATUSES,
                 cache_key=f"bilibili:{bvid}:{page_idx + 1}",
                 cache_variant="source",
                 ext_headers=bilip.headers,

--- a/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
@@ -59,9 +59,7 @@ from .live import RoomData
 from .opus import ImageNode, OpusItem, TextNode
 from .video import AIConclusion, VideoInfo
 
-_BILI_RETRYABLE_HTTP_STATUSES = frozenset(
-    {403, 404, 408, 425, 429, *range(500, 600)}
-)
+_BILI_RETRYABLE_HTTP_STATUSES = frozenset({403, 404, 408, 425, 429, *range(500, 600)})
 
 
 class BilibiliParser(BaseParser):
@@ -300,7 +298,7 @@ class BilibiliParser(BaseParser):
         url = f"https://bilibili.com/{video_info.bvid}"
         url += f"?p={page_info.index + 1}" if page_info.index > 0 else ""
 
-        video_stream, audio_stream = await self._extract_download_streams(
+        video_stream, audio_stream = await self.get_download_streams(
             video=video, page_index=page_info.index
         )
         video_urls = (video_stream.url, *video_stream.backup_url)
@@ -946,15 +944,18 @@ class BilibiliParser(BaseParser):
         else:
             raise ParseException("avid 和 bvid 至少指定一项")
 
-    async def extract_download_urls(
+    async def get_download_streams(
         self,
         video: Video | None = None,
         *,
         bvid: str | None = None,
         avid: int | None = None,
         page_index: int = 0,
-    ) -> tuple[str, str | None]:
-        """解析视频下载链接
+    ) -> tuple[
+        VideoStreamDownloadURL | FLVStreamDownloadURL | MP4StreamDownloadURL,
+        AudioStreamDownloadURL | None,
+    ]:
+        """获取最佳视频和音频下载流，并保留备用 CDN 地址。
 
         :param bvid: bvid
         :param avid: avid
@@ -964,22 +965,6 @@ class BilibiliParser(BaseParser):
         if video is None:
             video = await self._get_video(bvid=bvid, avid=avid)
 
-        video_stream, audio_stream = await self._extract_download_streams(
-            video=video, page_index=page_index
-        )
-        if audio_stream is None:
-            return video_stream.url, None
-        return video_stream.url, audio_stream.url
-
-    async def _extract_download_streams(
-        self,
-        video: Video,
-        page_index: int = 0,
-    ) -> tuple[
-        VideoStreamDownloadURL | FLVStreamDownloadURL | MP4StreamDownloadURL,
-        AudioStreamDownloadURL | None,
-    ]:
-        """选择下载流，并保留同一媒体的备用 CDN 地址"""
         download_url_data = await video.get_download_url(page_index=page_index)
         detecter = VideoDownloadURLDataDetecter(download_url_data)
         streams = detecter.detect_best_streams(

--- a/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
@@ -59,12 +59,14 @@ from .live import RoomData
 from .opus import ImageNode, OpusItem, TextNode
 from .video import AIConclusion, VideoInfo
 
-_BILI_RETRYABLE_HTTP_STATUSES = frozenset({403, 404, 408, 425, 429, *range(500, 600)})
-
 
 class BilibiliParser(BaseParser):
     platform: ClassVar[Platform] = Platform(
         name=PlatformEnum.BILIBILI, display_name="哔哩哔哩"
+    )
+
+    BILI_RETRYABLE_HTTP_STATUSES = frozenset(
+        {403, 404, 408, 425, 429, *range(500, 600)}
     )
 
     def __init__(self):
@@ -306,6 +308,7 @@ class BilibiliParser(BaseParser):
             (audio_stream.url, *audio_stream.backup_url) if audio_stream else None
         )
         cache_key = f"bilibili:{video_info.bvid}:{page_info.index + 1}"
+        retryable_http_statuses = self.BILI_RETRYABLE_HTTP_STATUSES
 
         class BiliVideoDownloader:
             def __init__(
@@ -327,7 +330,7 @@ class BilibiliParser(BaseParser):
                         audio_url=self.audio_urls[0],
                         video_fallback_urls=self.video_urls[1:],
                         audio_fallback_urls=self.audio_urls[1:],
-                        retry_http_statuses=_BILI_RETRYABLE_HTTP_STATUSES,
+                        retry_http_statuses=retryable_http_statuses,
                         cache_key=cache_key,
                         ext_headers=self.ext_headers,
                     )
@@ -335,7 +338,7 @@ class BilibiliParser(BaseParser):
                 return await DOWNLOADER.download_video(
                     url=self.url,
                     fallback_urls=self.video_urls[1:],
-                    retry_http_statuses=_BILI_RETRYABLE_HTTP_STATUSES,
+                    retry_http_statuses=retryable_http_statuses,
                     cache_key=cache_key,
                     cache_variant="source",
                     ext_headers=self.ext_headers,

--- a/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
@@ -28,7 +28,14 @@ from ...utils.bilibili.live import LiveRoom
 from ...utils.bilibili.login import QrCodeLogin, QrCodeLoginEvents
 from ...utils.bilibili.opus import Opus
 from ...utils.bilibili.user import get_black_list
-from ...utils.bilibili.video import Video, VideoDownloadURLDataDetecter
+from ...utils.bilibili.video import (
+    AudioStreamDownloadURL,
+    FLVStreamDownloadURL,
+    MP4StreamDownloadURL,
+    Video,
+    VideoDownloadURLDataDetecter,
+    VideoStreamDownloadURL,
+)
 from ...utils.cookie import ck2dict
 from ...utils.format import format_num
 from ..base import (
@@ -51,6 +58,10 @@ from .favlist import FavData
 from .live import RoomData
 from .opus import ImageNode, OpusItem, TextNode
 from .video import AIConclusion, VideoInfo
+
+_BILI_RETRYABLE_HTTP_STATUSES = frozenset(
+    {403, 404, 408, 425, 429, *range(500, 600)}
+)
 
 
 class BilibiliParser(BaseParser):
@@ -289,40 +300,50 @@ class BilibiliParser(BaseParser):
         url = f"https://bilibili.com/{video_info.bvid}"
         url += f"?p={page_info.index + 1}" if page_info.index > 0 else ""
 
-        v_url, a_url = await self.extract_download_urls(
+        video_stream, audio_stream = await self._extract_download_streams(
             video=video, page_index=page_info.index
+        )
+        video_urls = (video_stream.url, *video_stream.backup_url)
+        audio_urls = (
+            (audio_stream.url, *audio_stream.backup_url) if audio_stream else None
         )
         cache_key = f"bilibili:{video_info.bvid}:{page_info.index + 1}"
 
         class BiliVideoDownloader:
             def __init__(
                 self,
-                url: str,
-                audio_url: str | None,
+                video_urls: tuple[str, ...],
+                audio_urls: tuple[str, ...] | None,
                 ext_headers: dict[str, str] | None,
             ):
-                self.url = url
-                self.audio_url = audio_url
+                self.url = video_urls[0]
+                self.video_urls = video_urls
+                self.audio_urls = audio_urls
                 self.ext_headers = ext_headers
 
             async def __call__(self) -> Path:
                 # 有单独音频流时，走 av 合并
-                if self.audio_url:
+                if self.audio_urls:
                     return await DOWNLOADER.download_av_and_merge(
                         video_url=self.url,
-                        audio_url=self.audio_url,
+                        audio_url=self.audio_urls[0],
+                        video_fallback_urls=self.video_urls[1:],
+                        audio_fallback_urls=self.audio_urls[1:],
+                        retry_http_statuses=_BILI_RETRYABLE_HTTP_STATUSES,
                         cache_key=cache_key,
                         ext_headers=self.ext_headers,
                     )
                 # 否则直接用流式下载
                 return await DOWNLOADER.download_video(
                     url=self.url,
+                    fallback_urls=self.video_urls[1:],
+                    retry_http_statuses=_BILI_RETRYABLE_HTTP_STATUSES,
                     cache_key=cache_key,
                     cache_variant="source",
                     ext_headers=self.ext_headers,
                 )
 
-        downloader = BiliVideoDownloader(v_url, a_url, self.headers)
+        downloader = BiliVideoDownloader(video_urls, audio_urls, self.headers)
 
         video_content = self.create_video(
             url_or_task=downloader,
@@ -943,6 +964,22 @@ class BilibiliParser(BaseParser):
         if video is None:
             video = await self._get_video(bvid=bvid, avid=avid)
 
+        video_stream, audio_stream = await self._extract_download_streams(
+            video=video, page_index=page_index
+        )
+        if audio_stream is None:
+            return video_stream.url, None
+        return video_stream.url, audio_stream.url
+
+    async def _extract_download_streams(
+        self,
+        video: Video,
+        page_index: int = 0,
+    ) -> tuple[
+        VideoStreamDownloadURL | FLVStreamDownloadURL | MP4StreamDownloadURL,
+        AudioStreamDownloadURL | None,
+    ]:
+        """选择下载流，并保留同一媒体的备用 CDN 地址"""
         download_url_data = await video.get_download_url(page_index=page_index)
         detecter = VideoDownloadURLDataDetecter(download_url_data)
         streams = detecter.detect_best_streams(
@@ -970,10 +1007,9 @@ class BilibiliParser(BaseParser):
             f" 编码: {getattr(video_stream, 'video_codecs', None)}"
         )
         audio_stream = streams[1]
-        if audio_stream is None:
-            return video_stream.url, None
-        logger.debug(f"音频流质量: {audio_stream.audio_quality.name}")
-        return video_stream.url, audio_stream.url
+        if audio_stream is not None:
+            logger.debug(f"音频流质量: {audio_stream.audio_quality.name}")
+        return video_stream, audio_stream
 
     async def _save_credential(self):
         """存储哔哩哔哩登录凭证"""

--- a/src/nonebot_plugin_parser_lite/utils/bilibili/video.py
+++ b/src/nonebot_plugin_parser_lite/utils/bilibili/video.py
@@ -403,14 +403,9 @@ def sanitize_stream_urls(
             continue
 
         source_urls = [stream.url, *stream.backup_url]
-        clean_urls = [url for url in source_urls if url and not is_pcdn_url(url)]
-        if not clean_urls:
-            clean_urls = [stream.url]
-
-        preferred_url = _replace_host(clean_urls[0])
-        download_urls = list(dict.fromkeys([preferred_url, *clean_urls]))
-        stream.url = download_urls[0]
-        stream.backup_url = download_urls[1:]
+        clean_urls = [url for url in source_urls if not is_pcdn_url(url)]
+        stream.url = _replace_host(clean_urls[0])
+        stream.backup_url = clean_urls[1:]
 
     return video, audio
 

--- a/src/nonebot_plugin_parser_lite/utils/bilibili/video.py
+++ b/src/nonebot_plugin_parser_lite/utils/bilibili/video.py
@@ -403,10 +403,14 @@ def sanitize_stream_urls(
             continue
 
         source_urls = [stream.url, *stream.backup_url]
-        clean_urls = [url for url in source_urls if not is_pcdn_url(url)]
-        stream.url = _replace_host(clean_urls[0])
-        stream.backup_url = clean_urls[1:]
-
+        clean_urls = [url for url in source_urls if not is_pcdn_url(url)] or [
+            stream.url
+        ]
+        download_urls = list(
+            dict.fromkeys([_replace_host(clean_urls[0]), *clean_urls[1:]])
+        )
+        stream.url = download_urls[0]
+        stream.backup_url = download_urls[1:]
     return video, audio
 
 

--- a/src/nonebot_plugin_parser_lite/utils/bilibili/video.py
+++ b/src/nonebot_plugin_parser_lite/utils/bilibili/video.py
@@ -381,9 +381,9 @@ def sanitize_stream_urls(
 
     逻辑：
 
-    1. 若 base_url 为 PCDN，则优先使用 backup_url 中第一个非 PCDN 链接；
-    2. 若 backup_url 里也没有非 PCDN，则保留原 base_url (真倒霉)
-    3. PCDN 清洗完成后，统一替换主链接与备用链接的 CDN
+    1. 过滤 PCDN 链接，优先使用 B 站返回的非 PCDN 地址；
+    2. 将地区或自定义 CDN 放在首位；
+    3. 保留 B 站返回的非 PCDN 原始地址作为故障切换线路
 
     :param video: 视频流 URL 信息
     :param audio: 音频流 URL 信息
@@ -391,16 +391,6 @@ def sanitize_stream_urls(
     :param cdn_domain: 自定义 CDN 域名，设置后优先于地区配置
     :return: (清洗后的 video, audio)
     """
-    for stream in (video, audio):
-        if stream is None:
-            continue
-
-        if is_pcdn_url(stream.url):
-            clean_backups = [url for url in stream.backup_url if not is_pcdn_url(url)]
-            if clean_backups:
-                stream.url = clean_backups[0]
-                stream.backup_url = clean_backups[1:]
-
     replacement_domain = (
         normalize_cdn_domain(cdn_domain) if cdn_domain and cdn_domain.strip() else None
     ) or choose_cdn_domain(cdn_region)
@@ -411,8 +401,16 @@ def sanitize_stream_urls(
     for stream in (video, audio):
         if stream is None:
             continue
-        stream.url = _replace_host(stream.url)
-        stream.backup_url = [_replace_host(url) for url in stream.backup_url]
+
+        source_urls = [stream.url, *stream.backup_url]
+        clean_urls = [url for url in source_urls if url and not is_pcdn_url(url)]
+        if not clean_urls:
+            clean_urls = [stream.url]
+
+        preferred_url = _replace_host(clean_urls[0])
+        download_urls = list(dict.fromkeys([preferred_url, *clean_urls]))
+        stream.url = download_urls[0]
+        stream.backup_url = download_urls[1:]
 
     return video, audio
 

--- a/tests/test_bilibili_cdn_fallback.py
+++ b/tests/test_bilibili_cdn_fallback.py
@@ -1,0 +1,92 @@
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+import sys
+from types import ModuleType
+
+import pytest
+
+ROOT = Path(__file__).parents[1]
+VIDEO_MODULE = (
+    ROOT / "src/nonebot_plugin_parser_lite/utils/bilibili/video.py"
+)
+TEST_PACKAGE = "_parser_lite_bilibili_video_test"
+VIDEO_MODULE_NAME = f"{TEST_PACKAGE}.video"
+
+
+def _module(name: str, **attrs):
+    module = ModuleType(name)
+    for key, value in attrs.items():
+        setattr(module, key, value)
+    sys.modules[name] = module
+    return module
+
+
+@pytest.fixture
+def video_module():
+    for name in list(sys.modules):
+        if name == TEST_PACKAGE or name.startswith(f"{TEST_PACKAGE}."):
+            sys.modules.pop(name)
+
+    package = _module(TEST_PACKAGE)
+    package.__path__ = [str(VIDEO_MODULE.parent)]
+    _module(f"{TEST_PACKAGE}.a2v", av2bv=lambda value: value, bv2av=lambda value: value)
+    _module(
+        f"{TEST_PACKAGE}.cdn",
+        choose_cdn_domain=lambda _region: "preferred.bilivideo.com",
+        normalize_cdn_domain=lambda domain: domain,
+    )
+    _module(f"{TEST_PACKAGE}.client", CLIENT=object())
+    _module(f"{TEST_PACKAGE}.credential", Credential=object)
+    _module(f"{TEST_PACKAGE}.exceptions", BiliHelperException=RuntimeError)
+    _module(
+        f"{TEST_PACKAGE}.sign",
+        encWbi=lambda *args, **kwargs: None,
+        getWbiKeys=lambda *args, **kwargs: None,
+    )
+
+    spec = spec_from_file_location(VIDEO_MODULE_NAME, VIDEO_MODULE)
+    assert spec is not None
+    assert spec.loader is not None
+    module = module_from_spec(spec)
+    sys.modules[VIDEO_MODULE_NAME] = module
+    spec.loader.exec_module(module)
+
+    yield module
+
+    for name in list(sys.modules):
+        if name == TEST_PACKAGE or name.startswith(f"{TEST_PACKAGE}."):
+            sys.modules.pop(name)
+
+
+def test_sanitize_stream_urls_keeps_clean_origins_as_fallbacks(video_module):
+    primary = "https://origin.bilivideo.com/video.m4s?token=1"
+    backup = "https://backup.bilivideo.com/video.m4s?token=2"
+    pcdn = "https://node.mcdn.bilivideo.cn/video.m4s?token=3"
+    stream = video_module.VideoStreamDownloadURL(
+        url=primary,
+        video_quality=video_module.BiliVideoQuality._1080P,
+        video_codecs=video_module.BiliVideoCodecs.AVC,
+        backup_url=[backup, pcdn],
+    )
+
+    sanitized, _ = video_module.sanitize_stream_urls(stream, None)
+
+    assert sanitized is stream
+    assert sanitized.url == "https://preferred.bilivideo.com/video.m4s?token=1"
+    assert sanitized.backup_url == [primary, backup]
+
+
+def test_sanitize_stream_urls_replaces_pcdn_primary_from_clean_backup(video_module):
+    pcdn = "https://node.mcdn.bilivideo.cn/video.m4s?token=1"
+    backup = "https://backup.bilivideo.com/video.m4s?token=2"
+    stream = video_module.VideoStreamDownloadURL(
+        url=pcdn,
+        video_quality=video_module.BiliVideoQuality._1080P,
+        video_codecs=video_module.BiliVideoCodecs.AVC,
+        backup_url=[backup],
+    )
+
+    sanitized, _ = video_module.sanitize_stream_urls(stream, None)
+
+    assert sanitized.url == "https://preferred.bilivideo.com/video.m4s?token=2"
+    assert sanitized.backup_url == [backup]

--- a/tests/test_downloader_content_encoding.py
+++ b/tests/test_downloader_content_encoding.py
@@ -241,6 +241,10 @@ async def _download_image(downloader, cache_manager):
     )
 
 
+async def _no_sleep(_delay):
+    return None
+
+
 @pytest.mark.asyncio
 async def test_file_download_forces_identity_encoding(downloader_modules):
     download, _, cache_manager = downloader_modules
@@ -254,6 +258,83 @@ async def test_file_download_forces_identity_encoding(downloader_modules):
     assert await path.read_bytes() == b"webp"
     assert client.requests[0]["headers"]["Accept-Encoding"] == "identity"
     assert "accept-encoding" not in client.requests[0]["headers"]
+
+
+@pytest.mark.asyncio
+async def test_retryable_http_status_rotates_to_fallback_url(
+    downloader_modules, monkeypatch
+):
+    download, _, cache_manager = downloader_modules
+    client = FakeClient(
+        [
+            FakeResponse(404),
+            FakeResponse(200, headers={"Content-Length": "5"}, chunks=[b"fresh"]),
+        ]
+    )
+    downloader = _new_downloader(download, client)
+    monkeypatch.setattr(download.asyncio, "sleep", _no_sleep)
+
+    path = await downloader.streamd(
+        url="https://primary.example/video.m4s",
+        fallback_urls=("https://backup.example/video.m4s",),
+        retry_http_statuses={404},
+        cache_key="video",
+        default_suffix=".m4s",
+        cache_type=cache_manager.MEDIA,
+    )
+
+    assert await path.read_bytes() == b"fresh"
+    assert [request["url"] for request in client.requests] == [
+        "https://primary.example/video.m4s",
+        "https://backup.example/video.m4s",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_retryable_http_status_retries_primary_without_fallback(
+    downloader_modules, monkeypatch
+):
+    download, _, cache_manager = downloader_modules
+    client = FakeClient(
+        [
+            FakeResponse(404),
+            FakeResponse(200, headers={"Content-Length": "5"}, chunks=[b"fresh"]),
+        ]
+    )
+    downloader = _new_downloader(download, client)
+    monkeypatch.setattr(download.asyncio, "sleep", _no_sleep)
+
+    path = await downloader.streamd(
+        url="https://primary.example/video.m4s",
+        retry_http_statuses={404},
+        cache_key="video",
+        default_suffix=".m4s",
+        cache_type=cache_manager.MEDIA,
+    )
+
+    assert await path.read_bytes() == b"fresh"
+    assert [request["url"] for request in client.requests] == [
+        "https://primary.example/video.m4s",
+        "https://primary.example/video.m4s",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_unlisted_http_status_is_not_retried(downloader_modules):
+    download, _, cache_manager = downloader_modules
+    client = FakeClient([FakeResponse(404)])
+    downloader = _new_downloader(download, client)
+
+    with pytest.raises(RuntimeError, match="HTTP 404"):
+        await downloader.streamd(
+            url="https://cdn.example/missing.webp",
+            retry_http_statuses={503},
+            cache_key="missing",
+            default_suffix=".webp",
+            cache_type=cache_manager.MEDIA,
+        )
+
+    assert len(client.requests) == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Sourcery 摘要

通过在备用 CDN URL 之间重试，使 Bilibili 媒体下载能够从临时 HTTP 故障中恢复。

新功能：
- 支持在去重后的备用 CDN URL 之间轮换下载视频、音频和合并媒体。
- 允许调用方指定会触发重试或切换 CDN 的 HTTP 状态码。

错误修复：
- 通过保留干净的源 CDN 地址作为备用地址，而不是将其丢弃，提升 Bilibili 媒体的健壮性。

增强：
- 在保留首选 CDN 选择的同时，保留备用的非 PCDN 流 URL，以便进行恢复。

测试：
- 增加对 Bilibili CDN 清理的测试，以及针对备用 URL 和可重试 HTTP 状态码的重试行为测试。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

通过在保留的 CDN 备用 URL 之间重试临时性 HTTP 失败，提升 Bilibili 媒体下载的弹性。

新功能：
- 支持在下载视频、音频和合并媒体时，轮换使用去重后的备用 CDN URL。
- 允许调用方配置触发重试或 CDN 备用切换的 HTTP 状态码。

错误修复：
- 将清理 URL 时原本会被丢弃的 Bilibili 源 CDN URL 保留为备用路由。

增强：
- 保留首选 CDN 的选择，同时保留可用于故障恢复的其他非 PCDN 流。

测试：
- 增加对 Bilibili CDN URL 清理的覆盖测试，以及针对备用 URL 和已配置 HTTP 状态码的重试行为测试。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

通过在保留的 CDN 备用 URL 之间重试临时性 HTTP 故障，提高 Bilibili 媒体下载的可靠性。

新功能：
- 下载视频、音频和合并媒体时，支持在去重后的备用 CDN URL 之间轮换。
- 允许调用方配置触发重试或切换 CDN 备用地址的 HTTP 状态码。

错误修复：
- 在 URL 清理过程中保留干净的原始 Bilibili CDN URL，避免将其丢弃为备用路径。

增强功能：
- 保留首选 CDN 的选择，同时保留其他非 PCDN 流，以便在发生故障时恢复。

测试：
- 增加对 Bilibili CDN URL 清理的覆盖测试，以及使用备用 URL 和已配置 HTTP 状态码时的重试行为测试。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

通过在可用的 CDN 备用 URL 之间进行重试，提升 Bilibili 媒体下载对临时 HTTP 故障的容错能力。

新功能：
- 下载视频、音频和合并媒体时，支持在去重后的备用 CDN URL 之间轮换。
- 允许调用方配置触发重试或切换 CDN 备用地址的 HTTP 状态码。

错误修复：
- 将经过清理的原始 Bilibili CDN URL 保留为备用路径，而不是在 URL 清理过程中丢弃。

增强功能：
- 保留首选 CDN 的选择，同时保留其他可用于恢复的非 PCDN 流。

测试：
- 增加对 Bilibili CDN URL 清理的测试，以及使用备用 URL 和已配置 HTTP 状态码时的重试行为测试。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

通过在可用的 CDN 备用线路之间重试瞬时 HTTP 失败，提高 Bilibili 媒体下载的可靠性。

新功能：
- 支持在下载视频、音频和合并媒体时，轮换使用去重后的备用 CDN URL。
- 允许调用方配置触发重试或切换 CDN 备用线路的 HTTP 状态码。

错误修复：
- 在 URL 清理过程中，保留干净的 Bilibili 源 CDN URL 作为备用线路，而不是将其丢弃。

增强：
- 保留首选 CDN，同时保留其他非 PCDN 流，以便在发生故障时恢复。

测试：
- 增加对 Bilibili CDN URL 清理逻辑的测试，以及使用备用 URL 和已配置 HTTP 状态码时重试行为的测试。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

通过在可用的 CDN 备用线路之间重试临时性 HTTP 故障，提高 Bilibili 媒体下载的稳定性。

新功能：
- 为视频、音频和合并媒体下载添加可配置的备用 URL 轮换功能，以及基于 HTTP 状态码的重试支持。

错误修复：
- 将清理 URL 时未被丢弃的干净 Bilibili 源站 CDN URL 保留为备用线路。

增强功能：
- 保留首选 CDN 的选择，同时保留去重后的非 PCDN 流，以便在发生故障时恢复。

测试：
- 增加对 Bilibili CDN URL 清理功能，以及下载器针对可重试和不可重试 HTTP 状态码的备用行为的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

通过在可用的 CDN 备用地址之间重试瞬态 HTTP 故障，提高 Bilibili 媒体下载的稳定性。

新功能：
- 为视频、音频和合并媒体下载添加可配置的备用 URL 轮换机制，以及基于 HTTP 状态码的重试机制。

错误修复：
- 将经过清理的原始 Bilibili CDN URL 保留为备用路由，而不是在 URL 清理过程中丢弃。

增强功能：
- 保留首选 CDN，同时保留去重后的非 PCDN 流，以便在发生故障时恢复。

测试：
- 增加对 Bilibili CDN URL 清理功能的覆盖，并测试下载器针对可重试和不可重试 HTTP 状态码的备用行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve Bilibili media download resilience by retrying transient HTTP failures across available CDN fallbacks.

New Features:
- Add configurable fallback URL rotation and HTTP-status-based retries for video, audio, and merged media downloads.

Bug Fixes:
- Preserve clean original Bilibili CDN URLs as fallback routes instead of discarding them during URL sanitization.

Enhancements:
- Retain the preferred CDN while keeping deduplicated non-PCDN streams available for recovery.

Tests:
- Add coverage for Bilibili CDN URL sanitization and downloader fallback behavior for retryable and non-retryable HTTP statuses.

</details>

</details>

</details>

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

通过在保留的 CDN 备用 URL 之间重试临时性 HTTP 失败，提升 Bilibili 媒体下载的弹性。

新功能：
- 支持在下载视频、音频和合并媒体时，轮换使用去重后的备用 CDN URL。
- 允许调用方配置触发重试或 CDN 备用切换的 HTTP 状态码。

错误修复：
- 将清理 URL 时原本会被丢弃的 Bilibili 源 CDN URL 保留为备用路由。

增强：
- 保留首选 CDN 的选择，同时保留可用于故障恢复的其他非 PCDN 流。

测试：
- 增加对 Bilibili CDN URL 清理的覆盖测试，以及针对备用 URL 和已配置 HTTP 状态码的重试行为测试。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

通过在保留的 CDN 备用 URL 之间重试临时性 HTTP 故障，提高 Bilibili 媒体下载的可靠性。

新功能：
- 下载视频、音频和合并媒体时，支持在去重后的备用 CDN URL 之间轮换。
- 允许调用方配置触发重试或切换 CDN 备用地址的 HTTP 状态码。

错误修复：
- 在 URL 清理过程中保留干净的原始 Bilibili CDN URL，避免将其丢弃为备用路径。

增强功能：
- 保留首选 CDN 的选择，同时保留其他非 PCDN 流，以便在发生故障时恢复。

测试：
- 增加对 Bilibili CDN URL 清理的覆盖测试，以及使用备用 URL 和已配置 HTTP 状态码时的重试行为测试。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

通过在可用的 CDN 备用 URL 之间进行重试，提升 Bilibili 媒体下载对临时 HTTP 故障的容错能力。

新功能：
- 下载视频、音频和合并媒体时，支持在去重后的备用 CDN URL 之间轮换。
- 允许调用方配置触发重试或切换 CDN 备用地址的 HTTP 状态码。

错误修复：
- 将经过清理的原始 Bilibili CDN URL 保留为备用路径，而不是在 URL 清理过程中丢弃。

增强功能：
- 保留首选 CDN 的选择，同时保留其他可用于恢复的非 PCDN 流。

测试：
- 增加对 Bilibili CDN URL 清理的测试，以及使用备用 URL 和已配置 HTTP 状态码时的重试行为测试。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

通过在可用的 CDN 备用线路之间重试瞬时 HTTP 失败，提高 Bilibili 媒体下载的可靠性。

新功能：
- 支持在下载视频、音频和合并媒体时，轮换使用去重后的备用 CDN URL。
- 允许调用方配置触发重试或切换 CDN 备用线路的 HTTP 状态码。

错误修复：
- 在 URL 清理过程中，保留干净的 Bilibili 源 CDN URL 作为备用线路，而不是将其丢弃。

增强：
- 保留首选 CDN，同时保留其他非 PCDN 流，以便在发生故障时恢复。

测试：
- 增加对 Bilibili CDN URL 清理逻辑的测试，以及使用备用 URL 和已配置 HTTP 状态码时重试行为的测试。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

通过在可用的 CDN 备用线路之间重试临时性 HTTP 故障，提高 Bilibili 媒体下载的稳定性。

新功能：
- 为视频、音频和合并媒体下载添加可配置的备用 URL 轮换功能，以及基于 HTTP 状态码的重试支持。

错误修复：
- 将清理 URL 时未被丢弃的干净 Bilibili 源站 CDN URL 保留为备用线路。

增强功能：
- 保留首选 CDN 的选择，同时保留去重后的非 PCDN 流，以便在发生故障时恢复。

测试：
- 增加对 Bilibili CDN URL 清理功能，以及下载器针对可重试和不可重试 HTTP 状态码的备用行为的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

通过在可用的 CDN 备用地址之间重试瞬态 HTTP 故障，提高 Bilibili 媒体下载的稳定性。

新功能：
- 为视频、音频和合并媒体下载添加可配置的备用 URL 轮换机制，以及基于 HTTP 状态码的重试机制。

错误修复：
- 将经过清理的原始 Bilibili CDN URL 保留为备用路由，而不是在 URL 清理过程中丢弃。

增强功能：
- 保留首选 CDN，同时保留去重后的非 PCDN 流，以便在发生故障时恢复。

测试：
- 增加对 Bilibili CDN URL 清理功能的覆盖，并测试下载器针对可重试和不可重试 HTTP 状态码的备用行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve Bilibili media download resilience by retrying transient HTTP failures across available CDN fallbacks.

New Features:
- Add configurable fallback URL rotation and HTTP-status-based retries for video, audio, and merged media downloads.

Bug Fixes:
- Preserve clean original Bilibili CDN URLs as fallback routes instead of discarding them during URL sanitization.

Enhancements:
- Retain the preferred CDN while keeping deduplicated non-PCDN streams available for recovery.

Tests:
- Add coverage for Bilibili CDN URL sanitization and downloader fallback behavior for retryable and non-retryable HTTP statuses.

</details>

</details>

</details>

</details>

</details>

</details>

</details>

</details>