### PR TITLE
fix(download): 修复部分文件无法识别后缀

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ anyio>=4.0.0,<5.0.0
 ujson>=5.0.0,<6.0.0
 cryptography>45.0.0
 qrcode>=8.0,<9.0
+puremagic>=1.30

--- a/src/nonebot_plugin_parser_lite/download/__init__.py
+++ b/src/nonebot_plugin_parser_lite/download/__init__.py
@@ -227,7 +227,12 @@ class StreamDownloader:
                     retry_http_statuses=retry_http_statuses,
                     use_curl_cffi=use_curl_cffi,
                 )
-                suffix = await _detect_file_suffix(partial_path, default_suffix)
+                suffix = await _detect_file_suffix(
+                    partial_path,
+                    default_suffix
+                    if default_suffix.startswith(".")
+                    else f".{default_suffix}",
+                )
                 file_path = base_path.with_suffix(suffix)
                 if await file_path.exists():
                     await safe_unlink(partial_path)

--- a/src/nonebot_plugin_parser_lite/download/__init__.py
+++ b/src/nonebot_plugin_parser_lite/download/__init__.py
@@ -2,13 +2,13 @@ import asyncio
 from collections.abc import Callable, Collection, Generator, Sequence
 import contextlib
 from functools import partial
-import mimetypes
 import re
-from urllib.parse import urljoin, urlparse
+from urllib.parse import urljoin
 
 import aiofiles
 from anyio import Path
 from nonebot import logger
+import puremagic
 from rich.progress import (
     BarColumn,
     DownloadColumn,
@@ -32,14 +32,6 @@ from .client import RetryableDownloadError, UniHttpClient, UniResponse
 from .task import auto_task
 
 _RE_RANGE_PATTERN = re.compile(r"bytes\s+(\d+)-\d+/(\d+|\*)")
-_CONTENT_TYPE_SUFFIX_OVERRIDES = {
-    "audio/m4a": ".m4a",
-    "audio/mp4": ".m4a",
-    "audio/ogg": ".ogg",
-    "audio/webm": ".weba",
-    "audio/x-m4a": ".m4a",
-    "video/x-matroska": ".mkv",
-}
 
 
 def _with_identity_encoding(headers: dict[str, str]) -> dict[str, str]:
@@ -60,24 +52,14 @@ def _parse_content_encodings(value: str | None) -> tuple[str, ...]:
     )
 
 
-def _resolve_suffix(
-    url: str,
-    content_type: str | None,
-    default_suffix: str,
-) -> str:
-    if content_type:
-        media_type = content_type.partition(";")[0].strip().lower()
-        suffix = _CONTENT_TYPE_SUFFIX_OVERRIDES.get(
-            media_type
-        ) or mimetypes.guess_extension(media_type, strict=False)
-        if suffix:
-            suffix = suffix.lower()
-        if suffix:
-            return suffix
-
-    if url_suffix := Path(urlparse(url).path).suffix.lower():
-        return url_suffix
-    return default_suffix if default_suffix.startswith(".") else f".{default_suffix}"
+async def _detect_file_suffix(file_path: Path, default_suffix: str) -> str:
+    try:
+        return await asyncio.to_thread(
+            puremagic.from_file,
+            str(file_path),
+        )
+    except (OSError, puremagic.PureError):
+        return default_suffix
 
 
 class StreamDownloader:
@@ -157,7 +139,7 @@ class StreamDownloader:
         fallback_urls: Sequence[str] | None = None,
         retry_http_statuses: Collection[int] = (),
         cache_key: str | None = None,
-        default_suffix: str = ".bin",
+        default_suffix: str = ".dat",
         ext_headers: dict[str, str] | None = None,
         cache_type: str = CacheManager.MEDIA,
         use_curl_cffi: bool = False,
@@ -167,7 +149,7 @@ class StreamDownloader:
         :param fallback_urls: 主链接失败时轮换使用的同资源备用链接
         :param retry_http_statuses: 可通过重试或切换线路恢复的 HTTP 状态码
         :param cache_key: 稳定缓存标识，为空时根据 URL 生成
-        :param default_suffix: 响应和 URL 均无法确定后缀时使用的后缀名
+        :param default_suffix: puremagic 无法识别文件类型时使用的后缀名
         :param ext_headers: 额外的请求头，会与默认请求头合并
         :param cache_type: 缓存类型
         :param use_curl_cffi: 是否使用 curl_cffi 下载
@@ -178,15 +160,12 @@ class StreamDownloader:
         :raise DownloadException: 重试多次仍失败时抛出
         """
         cache_name = generate_file_name(url, cache_key)
-        fallback_suffix = _resolve_suffix(url, None, default_suffix)
         cache_dir = await CacheManager.ensure_dir(cache_type)
         base_path = cache_dir / cache_name
         partial_path = cache_dir / f"{cache_name}.part"
         download_urls = tuple(
             dict.fromkeys(
-                candidate
-                for candidate in (url, *(fallback_urls or ()))
-                if candidate
+                candidate for candidate in (url, *(fallback_urls or ())) if candidate
             )
         )
 
@@ -203,9 +182,9 @@ class StreamDownloader:
                 download_urls=download_urls,
                 base_path=base_path,
                 partial_path=partial_path,
-                fallback_suffix=fallback_suffix,
+                default_suffix=default_suffix,
                 headers=headers,
-                desc=f"{cache_name}{fallback_suffix}",
+                desc=f"{cache_name}{default_suffix}",
                 retry_http_statuses=frozenset(retry_http_statuses),
                 use_curl_cffi=use_curl_cffi,
             )
@@ -229,7 +208,7 @@ class StreamDownloader:
         download_urls: tuple[str, ...],
         base_path: Path,
         partial_path: Path,
-        fallback_suffix: str,
+        default_suffix: str,
         headers: dict[str, str],
         desc: str,
         retry_http_statuses: frozenset[int],
@@ -240,7 +219,7 @@ class StreamDownloader:
         for retry in range(self.MAX_RETRIES + 1):
             current_url = download_urls[retry % len(download_urls)]
             try:
-                content_type = await self.__download_once(
+                await self.__download_once(
                     url=current_url,
                     file_path=partial_path,
                     headers=headers,
@@ -248,7 +227,7 @@ class StreamDownloader:
                     retry_http_statuses=retry_http_statuses,
                     use_curl_cffi=use_curl_cffi,
                 )
-                suffix = _resolve_suffix(current_url, content_type, fallback_suffix)
+                suffix = await _detect_file_suffix(partial_path, default_suffix)
                 file_path = base_path.with_suffix(suffix)
                 if await file_path.exists():
                     await safe_unlink(partial_path)
@@ -325,7 +304,7 @@ class StreamDownloader:
         desc: str,
         retry_http_statuses: Collection[int],
         use_curl_cffi: bool,
-    ) -> str | None:
+    ):
         downloaded = (await file_path.stat()).st_size if await file_path.exists() else 0
         async with self.client.stream(
             "GET",
@@ -353,8 +332,6 @@ class StreamDownloader:
             content_length = (
                 None if zipped_content else response.headers.get("content-length")
             )
-            content_type = response.headers.get("content-type")
-
             total_size = (
                 downloaded + int(content_length)
                 if content_length and downloaded > 0
@@ -423,7 +400,6 @@ class StreamDownloader:
                         f"{self._SIZE_MISMATCH_TOLERANCE_BYTES} bytes)",
                         keep_part=final_size < total_size,
                     )
-            return content_type
 
     @auto_task
     async def download_video(

--- a/tests/test_downloader_content_encoding.py
+++ b/tests/test_downloader_content_encoding.py
@@ -3,6 +3,7 @@ from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
 import sys
 from types import ModuleType, SimpleNamespace
+from typing import ClassVar
 
 from httpx import DecodingError, Request, Timeout
 import pytest
@@ -137,6 +138,7 @@ def downloader_modules(tmp_path):
 
     class CacheManager:
         MEDIA = "media"
+        cached_files: ClassVar[list[tuple[object, object]]] = []
 
         @classmethod
         async def ensure_dir(cls, cache_type):
@@ -149,8 +151,8 @@ def downloader_modules(tmp_path):
             return None
 
         @classmethod
-        async def set_cached_file(cls, _base_path, _file_path):
-            return None
+        async def set_cached_file(cls, base_path, file_path):
+            cls.cached_files.append((base_path, file_path))
 
     async def safe_unlink(path):
         await path.unlink(missing_ok=True)
@@ -179,7 +181,7 @@ def downloader_modules(tmp_path):
     client = _load_module(f"{download_name}.client", download_path / "client.py")
     _load_module(f"{download_name}.task", download_path / "task.py")
     download_spec.loader.exec_module(download)
-    download.aiofiles = SimpleNamespace(open=AsyncFileStub)
+    download.aiofiles = SimpleNamespace(open=AsyncFileStub)  # type: ignore
 
     yield download, client, CacheManager
 
@@ -261,6 +263,63 @@ async def test_file_download_forces_identity_encoding(downloader_modules):
 
 
 @pytest.mark.asyncio
+async def test_generic_binary_content_type_uses_puremagic_and_updates_cache_meta(
+    downloader_modules,
+):
+    download, _, cache_manager = downloader_modules
+    client = FakeClient(
+        [
+            FakeResponse(
+                200,
+                headers={
+                    "Content-Length": "12",
+                    "Content-Type": "application/octet-stream",
+                },
+                chunks=[b"\x00\x00\x00\x18ftypisom"],
+            )
+        ]
+    )
+    downloader = _new_downloader(download, client)
+    path = await downloader.streamd(
+        url="https://cdn.example/media",
+        cache_key="video",
+        default_suffix=".dat",
+        cache_type=cache_manager.MEDIA,
+    )
+
+    assert path.name == "video.mp4"
+    assert cache_manager.cached_files[-1][1] is path
+
+
+@pytest.mark.asyncio
+async def test_unidentified_binary_uses_default_suffix(downloader_modules):
+    download, _, cache_manager = downloader_modules
+    client = FakeClient(
+        [
+            FakeResponse(
+                200,
+                headers={
+                    "Content-Length": "3",
+                    "Content-Type": "application/octet-stream",
+                },
+                chunks=[b"\x00\x01\x02"],
+            )
+        ]
+    )
+    downloader = _new_downloader(download, client)
+
+    path = await downloader.streamd(
+        url="https://cdn.example/media",
+        cache_key="unknown",
+        default_suffix=".dat",
+        cache_type=cache_manager.MEDIA,
+    )
+
+    assert path.name == "unknown.dat"
+    assert cache_manager.cached_files[-1][1] is path
+
+
+@pytest.mark.asyncio
 async def test_retryable_http_status_rotates_to_fallback_url(
     downloader_modules, monkeypatch
 ):
@@ -338,9 +397,7 @@ async def test_unlisted_http_status_is_not_retried(downloader_modules):
 
 
 @pytest.mark.asyncio
-async def test_legacy_part_416_is_removed_and_restarted(
-    downloader_modules, tmp_path
-):
+async def test_legacy_part_416_is_removed_and_restarted(downloader_modules, tmp_path):
     download, _, cache_manager = downloader_modules
     media_dir = tmp_path / cache_manager.MEDIA
     media_dir.mkdir()
@@ -474,7 +531,6 @@ async def test_decoding_error_discards_partial_file(downloader_modules, monkeypa
                 "invalid gzip stream",
                 request=Request("GET", "https://cdn.example/image.webp"),
             )
-            yield b""  # pragma: no cover
 
     monkeypatch.setattr(client_module, "HttpxResponse", BrokenHttpxResponse)
     response = client_module.UniResponse(BrokenHttpxResponse())


### PR DESCRIPTION
- 移除mimetypes模块依赖，改用puremagic库进行更准确的文件类型识别
- 删除自定义的_CONTENT_TYPE_SUFFIX_OVERRIDES映射表
- 新增_async_detect_file_suffix函数，通过puremagic.from_file检测文件后缀
- 将默认后缀从.bin改为.dat，并更新相关参数命名
- 修改下载逻辑，使用新的文件类型检测方法替代原有的URL和Content-Type解析方式
- 简化__download_once方法，移除content-type返回值

## Sourcery 总结

通过基于内容的文件类型识别，改进下载文件后缀的检测。

错误修复：
- 通过从文件内容中识别文件类型，而不是依赖 URL 和内容类型，改进下载文件扩展名的检测。

增强功能：
- 使用 puremagic 进行更准确的文件类型识别；当无法识别文件类型时，默认使用 `.dat` 后缀。
- 通过移除内容类型解析和自定义后缀覆盖映射，简化下载流程。

构建：
- 将 puremagic 添加为运行时依赖项。

测试：
- 增加对基于内容的扩展名检测、未知二进制文件回退行为以及缓存元数据更新的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

通过基于内容的类型识别和对未知文件使用安全的默认扩展名，改进下载文件后缀的检测。

错误修复：
- 通过识别文件内容而不是依赖 URL 和 HTTP 内容类型，改进下载文件扩展名的检测。

增强功能：
- 使用 puremagic 进行基于内容的文件类型检测；当无法识别文件类型时，回退使用 `.dat` 扩展名。
- 移除内容类型解析和自定义后缀覆盖逻辑，简化下载流程。

构建：
- 将 puremagic 添加为运行时依赖。

测试：
- 增加对基于内容的扩展名检测、未知二进制文件回退行为以及缓存元数据更新的覆盖测试。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

通过根据文件内容确定扩展名，并对无法识别的类型使用 `.dat`，改进下载文件的命名。

错误修复：
- 通过根据文件内容识别文件类型，而不是依赖 URL 和 HTTP 内容类型，改进下载文件扩展名的检测。

增强功能：
- 使用 puremagic 基于内容检测文件类型，并对无法识别的文件采用更安全的 `.dat` 扩展名作为备用方案。
- 通过移除内容类型解析和自定义后缀覆盖选项，简化下载流程。

构建：
- 将 puremagic 添加为运行时依赖项。

测试：
- 增加对基于内容的扩展名检测、未知二进制文件的备用行为以及缓存元数据更新的覆盖测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve downloaded file naming by determining extensions from file contents and using `.dat` for unrecognized types.

Bug Fixes:
- Improve downloaded file extension detection by identifying file types from file contents instead of relying on URLs and HTTP content types.

Enhancements:
- Use puremagic for content-based file type detection and fall back to the safer `.dat` extension for unrecognized files.
- Simplify the download flow by removing content-type parsing and custom suffix overrides.

Build:
- Add puremagic as a runtime dependency.

Tests:
- Add coverage for content-based extension detection, unknown binary fallback behavior, and cache metadata updates.

</details>

</details>

</details>