### PR TITLE
🐛 fix(bilibili): 修正 CDN 回退时的媒体体积统计

### DIFF
--- a/src/nonebot_plugin_parser_lite/download/__init__.py
+++ b/src/nonebot_plugin_parser_lite/download/__init__.py
@@ -123,6 +123,8 @@ class StreamDownloader:
         response = await self.head(
             url, ext_headers=ext_headers, use_curl_cffi=use_curl_cffi
         )
+        if not response.is_success:
+            return None
         raw_len = response.headers.get("content-length")
         if not raw_len:
             return None

--- a/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
@@ -57,6 +57,7 @@ from .dynamic import DynamicData, DynamicInfo
 from .favlist import FavData
 from .live import RoomData
 from .opus import ImageNode, OpusItem, TextNode
+from .size import get_source_stream_groups, probe_source_size
 from .video import AIConclusion, VideoInfo
 
 
@@ -353,6 +354,25 @@ class BilibiliParser(BaseParser):
             ext_headers=self.headers,
             cache_key=cache_key,
         )
+
+        # B 站视频与音频流分离时，卡片体积应包含两条源流。
+        source_url_groups = get_source_stream_groups(video_urls, audio_urls)
+
+        async def probe_head_size(url: str) -> int | None:
+            return await DOWNLOADER.head_size(
+                url=url,
+                ext_headers=self.headers,
+            )
+
+        source_sizes = await asyncio.gather(
+            *(probe_source_size(urls, probe_head_size) for urls in source_url_groups),
+            return_exceptions=True,
+        )
+        total_size = sum(
+            size for size in source_sizes if isinstance(size, int) and size > 0
+        )
+        if total_size:
+            video_content._size_bytes = total_size
 
         # 提取统计数据
         stats = self.create_stats()

--- a/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
@@ -355,9 +355,6 @@ class BilibiliParser(BaseParser):
             cache_key=cache_key,
         )
 
-        # B 站视频与音频流分离时，卡片体积应包含两条源流。
-        source_url_groups = get_source_stream_groups(video_urls, audio_urls)
-
         async def probe_head_size(url: str) -> int | None:
             return await DOWNLOADER.head_size(
                 url=url,
@@ -365,12 +362,10 @@ class BilibiliParser(BaseParser):
             )
 
         source_sizes = await asyncio.gather(
-            *(probe_source_size(urls, probe_head_size) for urls in source_url_groups),
+            *(probe_source_size(urls, probe_head_size) for urls in (video_urls, audio_urls)),
             return_exceptions=True,
         )
-        total_size = sum(
-            size for size in source_sizes if isinstance(size, int) and size > 0
-        )
+        total_size =  sum(filter(None, source_sizes))
         if total_size:
             video_content._size_bytes = total_size
 

--- a/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
@@ -365,7 +365,7 @@ class BilibiliParser(BaseParser):
             *(probe_source_size(urls, probe_head_size) for urls in (video_urls, audio_urls)),
             return_exceptions=True,
         )
-        total_size =  sum(filter(None, source_sizes))
+        total_size = sum(filter(None, source_sizes))
         if total_size:
             video_content._size_bytes = total_size
 

--- a/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
@@ -57,7 +57,7 @@ from .dynamic import DynamicData, DynamicInfo
 from .favlist import FavData
 from .live import RoomData
 from .opus import ImageNode, OpusItem, TextNode
-from .size import get_source_stream_groups, probe_source_size
+from .size import probe_source_size
 from .video import AIConclusion, VideoInfo
 
 
@@ -362,7 +362,10 @@ class BilibiliParser(BaseParser):
             )
 
         source_sizes = await asyncio.gather(
-            *(probe_source_size(urls, probe_head_size) for urls in (video_urls, audio_urls)),
+            *(
+                probe_source_size(urls, probe_head_size)
+                for urls in (video_urls, audio_urls)
+            ),
             return_exceptions=True,
         )
         total_size = sum(filter(None, source_sizes))

--- a/src/nonebot_plugin_parser_lite/parsers/bilibili/size.py
+++ b/src/nonebot_plugin_parser_lite/parsers/bilibili/size.py
@@ -1,27 +1,13 @@
-from collections.abc import Awaitable, Callable, Sequence
-
-
-def get_source_stream_groups(
-    video_urls: Sequence[str], audio_urls: Sequence[str] | None
-) -> tuple[tuple[str, ...], ...]:
-    """Return video and optional audio URLs grouped by fallback order."""
-    groups: list[tuple[str, ...]] = []
-    if video_urls:
-        groups.append(tuple(video_urls))
-    if audio_urls:
-        groups.append(tuple(audio_urls))
-    return tuple(groups)
+from collections.abc import Awaitable, Callable
 
 
 async def probe_source_size(
-    urls: Sequence[str], probe: Callable[[str], Awaitable[int | None]]
+    urls: tuple[str, ...],
+    probe: Callable[[str], Awaitable[int | None]],
 ) -> int | None:
-    """Return the first positive size from a stream's fallback URLs."""
     for url in urls:
         try:
-            size = await probe(url)
+            if size := await probe(url):
+                return size
         except Exception:
             continue
-        if isinstance(size, int) and size > 0:
-            return size
-    return None

--- a/src/nonebot_plugin_parser_lite/parsers/bilibili/size.py
+++ b/src/nonebot_plugin_parser_lite/parsers/bilibili/size.py
@@ -1,0 +1,27 @@
+from collections.abc import Awaitable, Callable, Sequence
+
+
+def get_source_stream_groups(
+    video_urls: Sequence[str], audio_urls: Sequence[str] | None
+) -> tuple[tuple[str, ...], ...]:
+    """Return video and optional audio URLs grouped by fallback order."""
+    groups: list[tuple[str, ...]] = []
+    if video_urls:
+        groups.append(tuple(video_urls))
+    if audio_urls:
+        groups.append(tuple(audio_urls))
+    return tuple(groups)
+
+
+async def probe_source_size(
+    urls: Sequence[str], probe: Callable[[str], Awaitable[int | None]]
+) -> int | None:
+    """Return the first positive size from a stream's fallback URLs."""
+    for url in urls:
+        try:
+            size = await probe(url)
+        except Exception:
+            continue
+        if isinstance(size, int) and size > 0:
+            return size
+    return None

--- a/tests/test_bilibili_source_size.py
+++ b/tests/test_bilibili_source_size.py
@@ -1,0 +1,58 @@
+import asyncio
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+
+SIZE_MODULE = (
+    Path(__file__).parents[1]
+    / "src/nonebot_plugin_parser_lite/parsers/bilibili/size.py"
+)
+spec = spec_from_file_location("_parser_lite_bilibili_size_test", SIZE_MODULE)
+assert spec is not None
+assert spec.loader is not None
+size_module = module_from_spec(spec)
+spec.loader.exec_module(size_module)
+
+get_source_stream_groups = size_module.get_source_stream_groups
+probe_source_size = size_module.probe_source_size
+
+
+def test_get_source_stream_groups_with_separate_audio():
+    video_urls = ("video-primary", "video-backup")
+    audio_urls = ("audio-primary", "audio-backup")
+
+    assert get_source_stream_groups(video_urls, audio_urls) == (
+        ("video-primary", "video-backup"),
+        ("audio-primary", "audio-backup"),
+    )
+
+
+def test_get_source_stream_groups_without_separate_audio():
+    video_urls = ("video-primary", "video-backup")
+
+    assert get_source_stream_groups(video_urls, None) == (
+        ("video-primary", "video-backup"),
+    )
+
+
+def test_probe_source_size_uses_first_successful_fallback():
+    calls = []
+
+    async def probe(url):
+        calls.append(url)
+        return {"video-primary": None, "video-backup": 320}.get(url)
+
+    assert (
+        asyncio.run(probe_source_size(("video-primary", "video-backup"), probe)) == 320
+    )
+    assert calls == ["video-primary", "video-backup"]
+
+
+def test_probe_source_size_ignores_probe_errors():
+    async def probe(url):
+        if url == "video-primary":
+            raise RuntimeError("HTTP 403")
+        return 320
+
+    assert (
+        asyncio.run(probe_source_size(("video-primary", "video-backup"), probe)) == 320
+    )

--- a/tests/test_downloader_content_encoding.py
+++ b/tests/test_downloader_content_encoding.py
@@ -234,6 +234,22 @@ def _new_downloader(download, client):
     return downloader
 
 
+@pytest.mark.asyncio
+async def test_head_size_ignores_error_response_length(downloader_modules):
+    download, _, _ = downloader_modules
+    downloader = object.__new__(download.StreamDownloader)
+
+    async def fake_head(*args, **kwargs):
+        return SimpleNamespace(
+            is_success=False,
+            headers={"content-length": "335000000"},
+        )
+
+    downloader.head = fake_head
+
+    assert await downloader.head_size("https://cdn.example/video.m4s") is None
+
+
 async def _download_image(downloader, cache_manager):
     return await downloader.streamd(
         url="https://cdn.example/image.webp",


### PR DESCRIPTION
## 主要变更

修正 B 站 CDN 回退场景下卡片媒体体积统计错误的问题。

当首选 CDN 返回错误响应时，旧逻辑可能把错误页的 `Content-Length` 当成媒体大小，并且只探测首选视频流，导致卡片体积明显小于实际下载体积。现在视频流和独立音频流分别按照主备 URL 顺序探测首个有效大小，再汇总写入 `VideoContent`。

## 实现细节

- `StreamDownloader.head_size()` 忽略非成功响应的 `Content-Length`。
- B 站视频、音频源流分别复用现有 CDN fallback 顺序进行体积探测。
- 保持实际下载 fallback、媒体格式处理和 200MB 限制逻辑不变。
- 增加 CDN 回退、无独立音频、探测异常和错误响应长度的回归测试。

## 验证

- B 站 CDN 与源流体积测试：`6 passed`
- 错误响应长度测试：`1 passed`
- 触及文件 `ruff check`、`ruff format --check`、`compileall`、冲突标记搜索和 `git diff --check` 通过

本地完整下载器测试未纳入通过结论：当前环境的 `puremagic.from_file` 在既有二进制识别测试中挂起，已由超时终止；未修改该无关测试或生产逻辑。

## Sourcery 摘要

修复 CDN 回退和独立音频流场景下的 Bilibili 媒体大小统计问题。

错误修复：
- 使用 CDN 回退时，通过忽略错误响应长度，并按回退顺序探测有效的视频和音频源，修正 Bilibili 媒体大小统计。

增强功能：
- 在卡片媒体元数据中包含独立视频流和音频流的大小，同时保留现有的下载回退和大小限制行为。

测试：
- 增加针对 CDN 回退探测、独立或缺失的音频流、探测失败以及无效错误响应长度的回归测试。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

修正 Bilibili CDN 回退场景下的媒体体积统计，使其基于有效的视频和音频源流大小。

错误修复：
- 修正 Bilibili CDN 回退时将错误响应的 `Content-Length` 误计为媒体大小的问题。
- 按视频和独立音频流的 CDN 回退顺序探测首个有效大小，确保卡片媒体体积统计完整准确。

功能增强：
- 保留现有的下载回退、媒体格式处理和大小限制行为，同时支持汇总独立视频与音频流的媒体大小。

测试：
- 增加 CDN 回退、独立音频或缺失音频、探测异常及错误响应长度的回归测试。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

通过在 CDN 回退场景中使用有效的视频和音频源大小，修复 Bilibili 媒体大小估算问题。

错误修复：
- 修正涉及 CDN 回退响应或独立音频流时的 Bilibili 媒体大小报告。
- 忽略失败 HEAD 响应中的 Content-Length 值，防止将错误页面计入媒体大小。

增强功能：
- 独立探测视频和独立音频回退源，并汇总第一个有效的大小，同时保留现有的下载回退和大小限制行为。

测试：
- 增加针对 CDN 回退顺序、独立或缺失的音频流、探测失败以及无效错误响应长度的回归测试。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

确保 Bilibili 卡片媒体大小基于有效的视频与音频源流准确统计。

Bug 修复：
- 修正 Bilibili CDN 回退时将错误响应的 Content-Length 计入媒体大小的问题。
- 修正独立视频和音频流场景下媒体总大小统计不完整的问题。

功能增强：
- 按视频和音频流各自的 CDN 回退顺序使用首个有效大小，并保留现有下载回退及大小限制行为。

测试：
- 增加 CDN 回退、独立或缺失音频、探测异常及错误响应长度的回归测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

确保 Bilibili 卡片媒体大小基于有效的视频与音频源流准确统计。

Bug Fixes:
- 修正 Bilibili CDN 回退时将错误响应的 Content-Length 计入媒体大小的问题。
- 修正独立视频和音频流场景下媒体总大小统计不完整的问题。

Enhancements:
- 按视频和音频流各自的 CDN 回退顺序使用首个有效大小，并保留现有下载回退及大小限制行为。

Tests:
- 增加 CDN 回退、独立或缺失音频、探测异常及错误响应长度的回归测试。

</details>

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

确保 Bilibili 卡片媒体大小基于有效的视频与音频源流准确统计。

Bug 修复：
- 修正 Bilibili CDN 回退时将错误响应的 Content-Length 计入媒体大小的问题。
- 修正独立视频和音频流场景下媒体总大小统计不完整的问题。

功能增强：
- 按视频和音频流各自的 CDN 回退顺序使用首个有效大小，并保留现有下载回退及大小限制行为。

测试：
- 增加 CDN 回退、独立或缺失音频、探测异常及错误响应长度的回归测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

确保 Bilibili 卡片媒体大小基于有效的视频与音频源流准确统计。

Bug Fixes:
- 修正 Bilibili CDN 回退时将错误响应的 Content-Length 计入媒体大小的问题。
- 修正独立视频和音频流场景下媒体总大小统计不完整的问题。

Enhancements:
- 按视频和音频流各自的 CDN 回退顺序使用首个有效大小，并保留现有下载回退及大小限制行为。

Tests:
- 增加 CDN 回退、独立或缺失音频、探测异常及错误响应长度的回归测试。

</details>

</details>

</details>

</details>

</details>