### PR TITLE
fix(render): 修复转发文本未包含标题

### DIFF
--- a/src/nonebot_plugin_parser_lite/render/__init__.py
+++ b/src/nonebot_plugin_parser_lite/render/__init__.py
@@ -411,6 +411,10 @@ class Renderer:
             nodes: list[ForwardNodeInner | _ForwardText] = []
             text_buffer: list[_ForwardTextPart] = []
             author_prefix_pending = True
+            if title := pr.title:
+                nodes.append(
+                    _ForwardText(author_name, [_ForwardTextPart(title)], False)
+                )
 
             async def flush_text() -> None:
                 nonlocal author_prefix_pending, text_buffer


### PR DESCRIPTION
当result存在标题时，在转发消息中添加标题作为文本节点， 以提供更好的上下文信息

## Sourcery 总结

错误修复：
- 如果有结果标题，则将其包含在转发的消息文本中，恢复缺失的上下文信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Include a result title in forwarded message text when one is available, restoring missing contextual information.

</details>