### PR TITLE
fix(taptap): 修复解析标签时报错

### DIFF
--- a/src/nonebot_plugin_parser_lite/parsers/taptap/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/taptap/__init__.py
@@ -27,6 +27,7 @@ class TapTapParser(BaseParser):
         self.httpx.base_url = "https://www.taptap.cn"
 
     @handle("www.taptap.cn", r"moment/(?P<moment_id>\d+)")
+    @handle("www.taptap.cn", r"explore/(?P<moment_id>\d+)")
     async def parse_moment(self, searched: MatchWithParams):
         moment_id = searched["moment_id"]
         resp = await self.httpx.get(

--- a/src/nonebot_plugin_parser_lite/parsers/taptap/share.py
+++ b/src/nonebot_plugin_parser_lite/parsers/taptap/share.py
@@ -45,14 +45,14 @@ class Contents(Struct):
                     else Creator.image(url=img.original_url)
                 )
             elif text := (desc or part.text):
-                content.append(text.strip())
+                content.append(text)
             return
 
         if part.text:
-            content.append(part.text.strip())
-        elif img:
+            content.append(part.text)
+        if img:
             content.append(Creator.image(url=img.original_url))
-        elif part.children:
+        if part.children:
             for child in part.children:
                 Contents._append_part(child, content)
 

--- a/src/nonebot_plugin_parser_lite/parsers/taptap/share.py
+++ b/src/nonebot_plugin_parser_lite/parsers/taptap/share.py
@@ -10,7 +10,7 @@ class Img(Struct):
 
 
 class Info(Struct):
-    img: Img
+    img: Img | None = None
     style: str | None = None
 
 
@@ -24,30 +24,43 @@ class Part(Struct):
 class Contents(Struct):
     json: list[Part]
 
+    @staticmethod
+    def _append_part(part: Part, content: list[ContentItem]) -> None:
+        info = part.info
+        img = info.img if info else None
+
+        if part.type == "tap_emoji":
+            desc = next(
+                (child.text for child in part.children or [] if child.text),
+                None,
+            )
+            if img:
+                content.append(
+                    Creator.sticker(
+                        url=img.original_url,
+                        size="small" if info and info.style == "inline" else "medium",
+                        desc=desc,
+                    )
+                    if desc
+                    else Creator.image(url=img.original_url)
+                )
+            elif text := (desc or part.text):
+                content.append(text.strip())
+            return
+
+        if part.text:
+            content.append(part.text.strip())
+        elif img:
+            content.append(Creator.image(url=img.original_url))
+        elif part.children:
+            for child in part.children:
+                Contents._append_part(child, content)
+
     @property
     def content(self) -> list[ContentItem]:
         content: list[ContentItem] = []
         for jpart in self.json:
-            if children := jpart.children:
-                for cpart in children:
-                    if text := cpart.text:
-                        content.append(text)
-                    elif info := cpart.info:
-                        if cpart.type == "tap_emoji":
-                            desc = cpart.children[0].text if cpart.children else None
-                            content.append(
-                                Creator.sticker(
-                                    url=info.img.original_url,
-                                    size="small"
-                                    if info.style == "inline"
-                                    else "medium",
-                                    desc=desc,
-                                )
-                            )
-                        else:
-                            content.append(Creator.image(url=info.img.original_url))
-            elif info := jpart.info:
-                content.append(Creator.image(info.img.original_url))
+            Contents._append_part(jpart, content)
             if jpart.type == "paragraph":
                 content.append("\n")
         return content


### PR DESCRIPTION
- 添加对 www.taptap.cn/explore/{moment_id} 路由的支持
- 优化分享内容解析，修复表情符号和图片处理逻辑
- 改进内容构建算法，支持更复杂的内容结构解析
- 将图片字段改为可选类型以提高代码健壮性
- resolve #291

## Sourcery 总结

改进 TapTap 动态解析，并使共享内容处理更加稳健。

新功能：
- 支持解析 TapTap 探索动态 URL。

错误修复：
- 修复包含表情符号、图片或缺少图片元数据的共享内容解析失败问题。

增强功能：
- 改进内容构建，以处理嵌套且更复杂的 TapTap 内容结构。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

改进 TapTap 动态解析，并使共享内容处理更加稳健。

新功能：
- 除了现有的动态 URL 外，支持解析 TapTap 探索动态 URL。

错误修复：
- 修复表情符号、图片以及缺少图片元数据的条目的共享内容解析问题。

增强功能：
- 改进内容解析，以便可靠地处理嵌套且更复杂的 TapTap 结构。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve TapTap moment parsing and make shared-content handling more robust.

New Features:
- Support parsing TapTap Explore moment URLs in addition to existing moment URLs.

Bug Fixes:
- Fix shared-content parsing for emojis, images, and entries with missing image metadata.

Enhancements:
- Improve content parsing to handle nested and more complex TapTap structures reliably.

</details>

</details>