### PR TITLE
fix(weibo): 修复解析包含音乐链接的微博报错

### DIFF
--- a/src/nonebot_plugin_parser_lite/parsers/weibo/statuses.py
+++ b/src/nonebot_plugin_parser_lite/parsers/weibo/statuses.py
@@ -51,15 +51,8 @@ class MediaInfo(Struct):
 class PageInfo(Struct):
     page_pic: str
     page_title: str
-    media_info: MediaInfo
-
-    def build_content(self, cache_key: str):
-        return Creator.video(
-            url_or_task=self.media_info.stream_url_hd,
-            cover_url=self.page_pic,
-            cache_key=cache_key,
-            ext_headers={"Referer": "https://weibo.com/"},
-        )
+    page_url: str
+    media_info: MediaInfo | None = None
 
 
 class User(Struct):
@@ -89,7 +82,7 @@ class WeiboData(Struct):
     region_name: str | None = None
     pic_infos: dict[str, Pic] | None = None
     page_info: PageInfo | None = None
-    """视频信息"""
+    """媒体信息"""
     retweeted_status: "WeiboData | None" = None
     """转发微博"""
 
@@ -106,10 +99,16 @@ class WeiboData(Struct):
         content = replace_placeholder_to_sticker(cleaned_text, WEIBO_PATTERN, "weibo")
         if self.pic_infos:
             content.extend(pic.content for pic in self.pic_infos.values())
-        if self.page_info:
+        if self.page_info and self.page_info.media_info:
             content.append(
-                self.page_info.build_content(cache_key=f"weibo:{self.idstr}")
+                Creator.video(
+                    url_or_task=self.page_info.media_info.stream_url_hd,
+                    cover_url=self.page_info.page_pic,
+                    cache_key=f"weibo:{self.idstr}",
+                    ext_headers={"Referer": "https://weibo.com/"},
+                )
             )
+
         return content
 
     @property


### PR DESCRIPTION
resolve #289

## Sourcery 总结

处理不含媒体的微博页面信息，使包含音乐链接的帖子能够成功解析。

错误修复：
- 防止微博解析器在页面信息不包含媒体的帖子上出错，例如包含音乐链接的帖子。

增强功能：
- 支持可选的页面媒体元数据，并在媒体可用时继续生成视频内容。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle Weibo page information without media so posts containing music links parse successfully.

Bug Fixes:
- Prevent Weibo parsing errors for posts whose page information does not contain media, such as posts with music links.

Enhancements:
- Support optional page media metadata while continuing to generate video content when media is available.

</details>