### PR TITLE
feat(bilibili): AI总结失败时不再影响视频解析

### DIFF
--- a/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
@@ -300,13 +300,17 @@ class BilibiliParser(BaseParser):
         elif video_info.pages:
             page_index = 0
 
-        if self._credential:
-            cid = await video.get_cid(page_index)
-            ai_conclusion = await video.get_ai_conclusion(cid)
-            ai_conclusion = convert(ai_conclusion, AIConclusion)
-            ai_summary = ai_conclusion.summary
-        else:
-            ai_summary: str = "哔哩哔哩 cookie 未配置或失效, 无法使用 AI 总结"
+        try:
+            if self._credential:
+                cid = await video.get_cid(page_index)
+                ai_conclusion = await video.get_ai_conclusion(cid)
+                ai_conclusion = convert(ai_conclusion, AIConclusion)
+                ai_summary = ai_conclusion.summary
+            else:
+                ai_summary = "哔哩哔哩 cookie 未配置或失效, 无法使用 AI 总结"
+        except Exception:
+            logger.exception("AI 总结获取失败")
+            ai_summary = None
 
         bvid = video_info.bvid or video.bvid
         url = f"https://bilibili.com/{bvid}"


### PR DESCRIPTION
为B站解析器的AI总结功能添加try-catch异常处理， 防止因API调用失败导致程序崩溃， 当AI总结获取失败时记录日志并返回None值。

## Sourcery 摘要

错误修复：
- 通过记录异常并在摘要获取失败时不返回摘要，防止 Bilibili AI 摘要失败中断视频解析。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent Bilibili AI summary failures from interrupting video parsing by logging the exception and returning no summary when retrieval fails.

</details>