### PR TITLE
fix(bilibili/quality): 修复哔哩视频质量和编码偏好配置不生效

### DIFF
--- a/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
+++ b/src/nonebot_plugin_parser_lite/parsers/bilibili/__init__.py
@@ -671,7 +671,11 @@ class BilibiliParser(BaseParser):
         if video is None:
             video = await self._get_video(bvid=bvid, avid=avid)
 
-        download_url_data = await video.get_download_url(page_index=page_index)
+        download_url_data = await video.get_download_url(
+            page_index=page_index,
+            prefer_codecs=pconfig.bili_video_codes,
+            video_quality=pconfig.bili_video_quality,
+        )
         detecter = VideoDownloadURLDataDetecter(download_url_data)
         streams = detecter.detect_best_streams(
             video_max_quality=pconfig.bili_video_quality,

--- a/src/nonebot_plugin_parser_lite/utils/bilibili/video.py
+++ b/src/nonebot_plugin_parser_lite/utils/bilibili/video.py
@@ -190,6 +190,7 @@ class Video:
         page_index: int | None = None,
         cid: int | None = None,
         prefer_codecs: list[BiliVideoCodecs] | None = None,
+        video_quality: BiliVideoQuality = BiliVideoQuality._4K,
     ) -> playurl_pb2.PlayViewReply:
         """
         获取视频下载信息
@@ -200,6 +201,8 @@ class Video:
 
         :param page_index: 分 P 号，从 0 开始, defaults to None
         :param cid: 分 P 的 ID, defaults to None
+        :param prefer_codecs: 偏好编码, defaults to None
+        :param video_quality: 请求最大视频质量, defaults to 4K
         :raises BiliHelperException: 传参有误
         :return: 调用 API 返回的结果
         """
@@ -221,9 +224,9 @@ class Video:
         req = playurl_pb2.PlayViewReq(
             aid=self.aid,
             cid=cid,
-            qn=127,
+            qn=video_quality.value,
             fnval=4048,
-            fourk=True,
+            fourk=video_quality.value >= BiliVideoQuality._4K.value,
             spmid="main.ugc-video-detail.0.0",
             from_spmid="main.my-history.0.0",
             prefer_codec_type=prefer_codec_type,

--- a/src/nonebot_plugin_parser_lite/utils/bilibili/video.py
+++ b/src/nonebot_plugin_parser_lite/utils/bilibili/video.py
@@ -190,7 +190,7 @@ class Video:
         page_index: int | None = None,
         cid: int | None = None,
         prefer_codecs: list[BiliVideoCodecs] | None = None,
-        video_quality: BiliVideoQuality = BiliVideoQuality._4K,
+        video_quality: BiliVideoQuality = BiliVideoQuality._8K,
     ) -> playurl_pb2.PlayViewReply:
         """
         获取视频下载信息


### PR DESCRIPTION
- 在BilibiliParser中传递视频质量和编码偏好配置参数到video.get_download_url方法
- 更新Video类的get_download_url方法以接收prefer_codecs和video_quality参数
- 将视频质量参数应用到API请求中，包括qn参数和fourk参数
- 添加相应的参数文档说明

## Summary by Sourcery

修复哔哩哔哩视频下载请求未使用质量与编码偏好配置的问题。

Bug Fixes:
- 使哔哩哔哩视频质量和编码偏好配置在下载地址请求中生效。

Enhancements:
- 将视频质量应用于 API 请求的最大画质和 4K 支持参数，并补充下载地址方法的参数文档。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

修复哔哩哔哩视频下载请求未使用质量与编码偏好配置的问题。

Bug Fixes:
- 使哔哩哔哩视频质量和编码偏好配置在下载地址请求中生效。

Enhancements:
- 将视频质量应用于 API 请求的最大画质和 4K 支持参数，并补充下载地址方法的参数文档。

</details>

<details>
<summary>Original summary in English</summary>



</details>