### PR TITLE
refactor(config): 移除视频时长限制配置项

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,9 +143,6 @@ plite_need_upload_video=False
 # 因此该配置项仅推荐 nonebot 和 协议端不在同一机器的用户配置
 plite_use_base64=False
 
-# [可选] 视频最大解析时长，单位：秒
-plite_duration_maximum=480
-
 # [可选] 音视频下载最大文件大小，单位 MB，超过该配置将阻断下载
 plite_max_size=90
 

--- a/src/nonebot_plugin_parser_lite/config.py
+++ b/src/nonebot_plugin_parser_lite/config.py
@@ -40,8 +40,6 @@ class Config(BaseModel):
     """是否使用 base64 编码发送图片，音频，视频"""
     plite_max_size: int = 90
     """资源最大大小，默认 90 单位 MB"""
-    plite_duration_maximum: int = 480
-    """视频/音频最大时长"""
     plite_append_url: bool = False
     """是否在解析结果中添加原始URL"""
     plite_embed_url: bool = False
@@ -133,11 +131,6 @@ class Config(BaseModel):
     def max_size(self) -> int:
         """资源最大大小(mb)"""
         return self.plite_max_size
-
-    @property
-    def duration_maximum(self) -> int:
-        """视频/音频最大时长(s)"""
-        return self.plite_duration_maximum
 
     @property
     def disabled_platforms(self) -> list[PlatformEnum]:

--- a/src/nonebot_plugin_parser_lite/exception.py
+++ b/src/nonebot_plugin_parser_lite/exception.py
@@ -33,14 +33,6 @@ class SizeLimitException(DownloadLimitException):
         self.size = round(size, 2)
 
 
-class DurationLimitException(DownloadLimitException):
-    """下载时长超过限制异常"""
-
-    def __init__(self, duration: float):
-        super().__init__("媒体时长超过配置限制，取消下载")
-        self.duration = round(duration, 2)
-
-
 class ZeroSizeException(DownloadException):
     """下载大小为 0 异常"""
 

--- a/src/nonebot_plugin_parser_lite/render/__init__.py
+++ b/src/nonebot_plugin_parser_lite/render/__init__.py
@@ -361,7 +361,6 @@ class Renderer:
 
         :raise ZeroSizeException: 资源大小为 0 时抛出
         :raise SizeLimitException: 资源大小超过配置的最大限制时抛出
-        :raise DurationLimitException: 媒体时长超过配置的最大限制时抛出
         :raise DownloadException: 重试多次仍失败时抛出
         """
         if not isinstance(cont, VideoContent | AudioContent):

--- a/src/nonebot_plugin_parser_lite/render/__init__.py
+++ b/src/nonebot_plugin_parser_lite/render/__init__.py
@@ -28,7 +28,6 @@ from ..data import (
 )
 from ..exception import (
     DownloadException,
-    DurationLimitException,
     SizeLimitException,
 )
 from ..helper import ForwardNodeInner, UniHelper, UniMessage
@@ -271,11 +270,6 @@ class Renderer:
                     f"媒体太大啦，还是去{result.platform.display_name}看看吧~"
                 )
                 continue
-            except DurationLimitException:
-                yield UniMessage(
-                    f"媒体太长啦，还是去{result.platform.display_name}看看吧~"
-                )
-                continue
             except DownloadException as e:
                 failed_count += 1
                 logger.exception(f"{cont.__class__.__name__} 下载失败: {e!r}")
@@ -372,9 +366,6 @@ class Renderer:
         """
         if not isinstance(cont, VideoContent | AudioContent):
             return
-        if cont.duration > pconfig.duration_maximum:
-            raise DurationLimitException(cont.duration)
-
         path = await cont.get_path()
         if (isinstance(cont, VideoContent) and pconfig.need_upload_video) or (
             not isinstance(cont, VideoContent)


### PR DESCRIPTION
移除了 plite_duration_maximum 配置项及相关功能， 包括配置定义、属性访问器和时长限制检查逻辑

## Sourcery 摘要

移除插件中可配置的媒体时长限制。

增强功能：
- 移除媒体时长限制配置及其相关的验证和错误处理。

文档：
- 从配置文档中移除已废弃的媒体时长限制设置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

移除媒体时长限制配置及其相关功能。

Enhancements:
- 移除可配置的音视频时长限制及其相关的校验、异常处理和用户提示。

Documentation:
- 从配置文档中移除已废弃的媒体时长限制设置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

移除媒体时长限制配置及其相关功能。

Enhancements:
- 移除可配置的音视频时长限制及其相关的校验、异常处理和用户提示。

Documentation:
- 从配置文档中移除已废弃的媒体时长限制设置。

</details>

</details>